### PR TITLE
Add tests for M2 exercises.

### DIFF
--- a/exercises/en/test_02_07a.py
+++ b/exercises/en/test_02_07a.py
@@ -1,0 +1,19 @@
+def test():
+    # Here we can either check objects created in the solution code, or the
+    # string value of the solution, available as __solution__. A helper for
+    # printing formatted messages is available as __msg__. See the testTemplate
+    # in the meta.json for details.
+    # If an assertion fails, the message will be displayed
+
+    assert not fuel_efficiency is None, "Your answer does not exist. Have you passed in the correct variable?"
+    assert type(fuel_efficiency) == type(alt.Chart()), "Your answer is not an altair Chart object. Check to make sure that you have assigned an alt.Chart object to fuel_efficiency."
+    assert fuel_efficiency.data.equals(data.cars()), "Make sure you are using cars() dataset from vega_datasets."
+    assert fuel_efficiency.mark == 'area', "Make sure you are using the area mark type."
+    assert (fuel_efficiency.encoding.x.field in {'Year', 'Year:temporal', 'Year:T'} or 
+            fuel_efficiency.encoding.x.shorthand in {'Year', 'Year:temporal', 'Year:T'}), "Make sure you are using 'Year' as the x-axis encoding."
+    assert (fuel_efficiency.encoding.y.field in {'Miles_per_Gallon', 'Miles_per_Gallon:quantitative', 'Miles_per_Gallon:Q'} or 
+            "Miles_per_Gallon" in fuel_efficiency.encoding.y.shorthand), "Make sure you are using mean of the 'Miles_per_Gallon' as the y-axis encoding."
+    assert ((fuel_efficiency.encoding.y.field in {'Miles_per_Gallon', 'Miles_per_Gallon:quantitative', 'Miles_per_Gallon:Q'} and fuel_efficiency.encoding.y.aggregate == 'mean') or
+            fuel_efficiency.encoding.y.shorthand in {'mean(Miles_per_Gallon)', 'mean(Miles_per_Gallon):quantitative', 'mean(Miles_per_Gallon):Q'}), "You're very close. Make sure that you are using the mean aggregate for the y-axis encoding."
+    assert type(fuel_efficiency.title) == str and len(fuel_efficiency.title) >= 5, "Make sure you specify a descriptive title for the fuel_efficiency plot."
+    __msg__.good("You're correct, well done!")

--- a/exercises/en/test_02_07a.py
+++ b/exercises/en/test_02_07a.py
@@ -6,7 +6,7 @@ def test():
     # If an assertion fails, the message will be displayed
 
     assert not fuel_efficiency is None, "Your answer does not exist. Have you passed in the correct variable?"
-    assert type(fuel_efficiency) == type(alt.Chart()), "Your answer is not an altair Chart object. Check to make sure that you have assigned an alt.Chart object to fuel_efficiency."
+    assert type(fuel_efficiency) == type(alt.Chart()), "Your answer is not an Altair Chart object. Check to make sure that you have assigned an alt.Chart object to fuel_efficiency."
     assert fuel_efficiency.data.equals(data.cars()), "Make sure you are using cars() dataset from vega_datasets."
     assert fuel_efficiency.mark == 'area', "Make sure you are using the area mark type."
     assert (fuel_efficiency.encoding.x.field in {'Year', 'Year:temporal', 'Year:T'} or 

--- a/exercises/en/test_02_07b.py
+++ b/exercises/en/test_02_07b.py
@@ -6,7 +6,7 @@ def test():
     # If an assertion fails, the message will be displayed
 
     assert not fuel_efficiency_org is None, "Your answer does not exist. Have you passed in the correct variable?"
-    assert type(fuel_efficiency_org) == type(alt.Chart()), "Your answer is not an altair Chart object. Check to make sure that you have assigned an alt.Chart object to fuel_efficiency_org."
+    assert type(fuel_efficiency_org) == type(alt.Chart()), "Your answer is not an Altair Chart object. Check to make sure that you have assigned an alt.Chart object to fuel_efficiency_org."
     assert fuel_efficiency_org.data.equals(data.cars()), "Make sure you are using cars() dataset from vega_datasets."
     assert fuel_efficiency_org.mark == 'area' or fuel_efficiency_org.mark == 'line', "Make sure you are using the area or line mark type."
     assert (fuel_efficiency_org.encoding.x.field in {'Year', 'Year:temporal', 'Year:T'} or

--- a/exercises/en/test_02_07b.py
+++ b/exercises/en/test_02_07b.py
@@ -1,0 +1,21 @@
+def test():
+    # Here we can either check objects created in the solution code, or the
+    # string value of the solution, available as __solution__. A helper for
+    # printing formatted messages is available as __msg__. See the testTemplate
+    # in the meta.json for details.
+    # If an assertion fails, the message will be displayed
+
+    assert not fuel_efficiency_org is None, "Your answer does not exist. Have you passed in the correct variable?"
+    assert type(fuel_efficiency_org) == type(alt.Chart()), "Your answer is not an altair Chart object. Check to make sure that you have assigned an alt.Chart object to fuel_efficiency_org."
+    assert fuel_efficiency_org.data.equals(data.cars()), "Make sure you are using cars() dataset from vega_datasets."
+    assert fuel_efficiency_org.mark == 'area' or fuel_efficiency_org.mark == 'line', "Make sure you are using the area or line mark type."
+    assert (fuel_efficiency_org.encoding.x.field in {'Year', 'Year:temporal', 'Year:T'} or
+            fuel_efficiency_org.encoding.x.shorthand in {'Year', 'Year:temporal', 'Year:T'}), "Make sure you are using 'Year' as the x-axis encoding."
+    assert (fuel_efficiency_org.encoding.y.field in {'Miles_per_Gallon', 'Miles_per_Gallon:quantitative', 'Miles_per_Gallon:Q'} or 
+            "Miles_per_Gallon" in fuel_efficiency_org.encoding.y.shorthand), "Make sure you are using mean of the 'Miles_per_Gallon' as the y-axis encoding."
+    assert ((fuel_efficiency_org.encoding.y.field == 'Miles_per_Gallon' and fuel_efficiency.encoding.y.aggregate == 'mean') or 
+            fuel_efficiency_org.encoding.y.shorthand in {'mean(Miles_per_Gallon)', 'mean(Miles_per_Gallon):quantitative', 'mean(Miles_per_Gallon):Q'}), "You're very close. Make sure that you are using the mean aggregate for the y-axis encoding."
+    assert (fuel_efficiency_org.encoding.color.field in {'Origin', 'Origin:nominal', 'Origin:N'} or 
+            fuel_efficiency_org.encoding.color.shorthand in {'Origin', 'Origin:nominal', 'Origin:N'}), "Make sure you are using 'Origin' as the color encoding."
+    assert type(fuel_efficiency_org.title) == str and len(fuel_efficiency_org.title) >= 5, "Make sure you specify a descriptive title for the fuel_efficiency_org plot." 
+    __msg__.good("You're correct, well done!")

--- a/exercises/en/test_02_11.py
+++ b/exercises/en/test_02_11.py
@@ -9,7 +9,7 @@ def test():
     # this might be the better way to test for the first exercise.
     # Maybe even for later exercises.
     assert not penguin_bar is None, "Your answer does not exist. Have you passed in the correct variable?"
-    assert type(penguin_bar) == type(alt.Chart()), "Your answer is not an altair Chart object. Check to make sure that you have assigned an alt.Chart object to penguin_bar."
+    assert type(penguin_bar) == type(alt.Chart()), "Your answer is not an Altair Chart object. Check to make sure that you have assigned an alt.Chart object to penguin_bar."
     assert penguin_bar.data.equals(penguins) and penguin_bar.data.shape == (344, 7), "Make sure you are using the penguins dataset."
     assert penguin_bar.mark == 'bar', "Make sure you are using the bar mark type."
     assert (penguin_bar.encoding.x.shorthand in {'count()', 'count():quantitative', 'count:Q'} or 

--- a/exercises/en/test_02_11.py
+++ b/exercises/en/test_02_11.py
@@ -1,0 +1,23 @@
+def test():
+    # Here we can either check objects created in the solution code, or the
+    # string value of the solution, available as __solution__. A helper for
+    # printing formatted messages is available as __msg__. See the testTemplate
+    # in the meta.json for details.
+    # If an assertion fails, the message will be displayed
+
+    # Since we haven't started assigning charts to variable names yet,
+    # this might be the better way to test for the first exercise.
+    # Maybe even for later exercises.
+    assert not penguin_bar is None, "Your answer does not exist. Have you passed in the correct variable?"
+    assert type(penguin_bar) == type(alt.Chart()), "Your answer is not an altair Chart object. Check to make sure that you have assigned an alt.Chart object to penguin_bar."
+    assert penguin_bar.data.equals(penguins) and penguin_bar.data.shape == (344, 7), "Make sure you are using the penguins dataset."
+    assert penguin_bar.mark == 'bar', "Make sure you are using the bar mark type."
+    assert (penguin_bar.encoding.x.shorthand in {'count()', 'count():quantitative', 'count:Q'} or 
+            penguin_bar.encoding.x.field in {'count()', 'count():quantitative', 'count:Q'}), "Make sure you are using 'count()' as the x-axis encoding."
+    assert (penguin_bar.encoding.y.field in {'species', 'species:nominal', 'species:N'} or 
+            penguin_bar.encoding.y.shorthand in {'species', 'species:nominal', 'species:N'}), "Make sure you are using 'species' as the y-axis encoding."
+    assert penguin_bar.encoding.y.sort != alt.utils.schemapi.Undefined, "Make sure you are specify the sort argument for the y-axis encoding."
+    assert type(penguin_bar.title) == str and len(penguin_bar.title) >= 5, "Make sure you specify a descriptive title for the penguin_bar plot."
+    assert penguin_bar.height == 150, "Make sure you specify the plot height of 150."
+    assert penguin_bar.width == 300, "Make sure you specify the plot width of 300." 
+    __msg__.good("You're correct, well done!")

--- a/exercises/en/test_02_12.py
+++ b/exercises/en/test_02_12.py
@@ -1,0 +1,23 @@
+def test():
+    # Here we can either check objects created in the solution code, or the
+    # string value of the solution, available as __solution__. A helper for
+    # printing formatted messages is available as __msg__. See the testTemplate
+    # in the meta.json for details.
+    # If an assertion fails, the message will be displayed
+
+    # Since we haven't started assigning charts to variable names yet,
+    # this might be the better way to test for the first exercise.
+    # Maybe even for later exercises.
+    assert not penguin_hist is None, "Your answer does not exist. Have you passed in the correct variable?"
+    assert type(penguin_hist) == type(alt.Chart()), "Your answer is not an altair Chart object. Check to make sure that you have assigned an alt.Chart object to penguin_hist."
+    assert penguin_hist.data.equals(penguins) and penguin_hist.data.shape == (344, 7), "Make sure you are using the penguins dataset."
+    assert penguin_hist.mark == 'bar', "Make sure you are using the bar mark type."
+    assert (penguin_hist.encoding.x.shorthand in {'flipper_length_mm', 'flipper_length_mm:quantitative', 'flipper_length_mm:Q'} or 
+            penguin_hist.encoding.x.field in {'flipper_length_mm', 'flipper_length_mm:quantitative', 'flipper_length_mm:Q'}), "Make sure you are using 'flipper_length_mm' as the x-axis encoding."
+    assert penguin_hist.encoding.x.bin != alt.utils.schemapi.Undefined, "Make sure you are specifying the bin argument for the x-axis encoding for the histogram."
+    assert (penguin_hist.encoding.y.field in {'count()', 'count():quantitative', 'count:Q'} or 
+            penguin_hist.encoding.y.shorthand in {'count()', 'count():quantitative', 'count:Q'}), "Make sure you are using 'count()' as the y-axis encoding."
+    assert type(penguin_hist.title) == str and len(penguin_hist.title) >= 5, "Make sure you specify a descriptive title for the penguin_hist plot."
+    assert penguin_hist.height == 150, "Make sure you specify the plot height of 150."
+    assert penguin_hist.width == 300, "Make sure you specify the plot width of 300." 
+    __msg__.good("You're correct, well done!")

--- a/exercises/en/test_02_12.py
+++ b/exercises/en/test_02_12.py
@@ -9,7 +9,7 @@ def test():
     # this might be the better way to test for the first exercise.
     # Maybe even for later exercises.
     assert not penguin_hist is None, "Your answer does not exist. Have you passed in the correct variable?"
-    assert type(penguin_hist) == type(alt.Chart()), "Your answer is not an altair Chart object. Check to make sure that you have assigned an alt.Chart object to penguin_hist."
+    assert type(penguin_hist) == type(alt.Chart()), "Your answer is not an Altair Chart object. Check to make sure that you have assigned an alt.Chart object to penguin_hist."
     assert penguin_hist.data.equals(penguins) and penguin_hist.data.shape == (344, 7), "Make sure you are using the penguins dataset."
     assert penguin_hist.mark == 'bar', "Make sure you are using the bar mark type."
     assert (penguin_hist.encoding.x.shorthand in {'flipper_length_mm', 'flipper_length_mm:quantitative', 'flipper_length_mm:Q'} or 

--- a/exercises/en/test_02_16.py
+++ b/exercises/en/test_02_16.py
@@ -1,0 +1,25 @@
+def test():
+    # Here we can either check objects created in the solution code, or the
+    # string value of the solution, available as __solution__. A helper for
+    # printing formatted messages is available as __msg__. See the testTemplate
+    # in the meta.json for details.
+    # If an assertion fails, the message will be displayed
+
+    # Since we haven't started assigning charts to variable names yet,
+    # this might be the better way to test for the first exercise.
+    # Maybe even for later exercises.
+    assert not penguin_facet is None, "Your answer does not exist. Have you passed in the correct variable?"
+    assert type(penguin_facet) == alt.vegalite.v4.api.FacetChart, "Your answer is not an altair FacetChart object. Check to make sure that you have assigned an alt.Chart object to penguin_facet and that you are facetting by 'species' for the columns and by 'island' for the rows."
+    assert penguin_facet.data.equals(penguins) and penguin_facet.data.shape == (344, 7), "Make sure you are using the penguins dataset."
+    assert penguin_facet.facet.column in {'species', 'species:nominal', 'species:N'}, "Make sure you are facetting by 'species' for the columns."
+    assert penguin_facet.facet.row in {'island', 'island:nominal', 'island:N'}, "Make sure you are facetting by 'island' for the rows."
+    assert penguin_facet.spec.mark == 'bar', "Make sure you are using the bar mark type."
+    assert (penguin_facet.spec.encoding.x.shorthand in {'body_mass_g', 'body_mass_g:quantitative', 'body_mass_g;Q'} or 
+            penguin_facet.spec.encoding.x.field in {'body_mass_g', 'body_mass_g:quantitative', 'body_mass_g;Q'}), "Make sure you are using 'body_mass_g' as the x-axis encoding."
+    assert penguin_facet.spec.encoding.x.bin != alt.utils.schemapi.Undefined, "Make sure you are specifying the bin argument for the x-axis encoding for the histogram."
+    assert (penguin_facet.spec.encoding.y.field in {'count()', 'count():quantitative', 'count:Q'} or 
+            penguin_facet.spec.encoding.y.shorthand in {'count()', 'count():quantitative', 'count:Q'}), "Make sure you are using 'count()' as the y-axis encoding."
+    assert type(penguin_facet.spec.title) == str and len(penguin_facet.spec.title) >= 5, "Make sure you specify a descriptive title for the penguin_bar plot."
+    assert penguin_facet.spec.height == 100, "Make sure you specify the plot height of 100."
+    assert penguin_facet.spec.width == 150, "Make sure you specify the plot width of 150."
+    __msg__.good("You're correct, well done!")

--- a/exercises/en/test_02_16.py
+++ b/exercises/en/test_02_16.py
@@ -9,7 +9,7 @@ def test():
     # this might be the better way to test for the first exercise.
     # Maybe even for later exercises.
     assert not penguin_facet is None, "Your answer does not exist. Have you passed in the correct variable?"
-    assert type(penguin_facet) == alt.vegalite.v4.api.FacetChart, "Your answer is not an altair FacetChart object. Check to make sure that you have assigned an alt.Chart object to penguin_facet and that you are facetting by 'species' for the columns and by 'island' for the rows."
+    assert type(penguin_facet) == alt.vegalite.v4.api.FacetChart, "Your answer is not an Altair FacetChart object. Check to make sure that you have assigned an alt.Chart object to penguin_facet and that you are facetting by 'species' for the columns and by 'island' for the rows."
     assert penguin_facet.data.equals(penguins) and penguin_facet.data.shape == (344, 7), "Make sure you are using the penguins dataset."
     assert penguin_facet.facet.column in {'species', 'species:nominal', 'species:N'}, "Make sure you are facetting by 'species' for the columns."
     assert penguin_facet.facet.row in {'island', 'island:nominal', 'island:N'}, "Make sure you are facetting by 'island' for the rows."


### PR DESCRIPTION
For the `test_02_12`, I assumed that the `flipper_length_mm` goes in x-axis and `count()` goes in the y-axis. 
Would it be possible to specify that in the instructions as well?

Similarly, for the `test_02_16`, I assumed that the `body_mass_g` goes in x-axis and `count()` goes in the y-axis. 

Please let me know what changes are needed!