### PR TITLE
Show interactive plots in slides

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -80,3 +80,9 @@ exports.createPages = ({ actions, graphql }) => {
         })
     })
 }
+
+
+const express= require('express');
+exports.onCreateDevServer=({app})=>{
+    app.use(express.static('public'))
+}

--- a/slide-setup.R
+++ b/slide-setup.R
@@ -16,6 +16,38 @@ knitr::knit_hooks$set(
         # Using element-wise `&&` to avoid raising warning for multi-line R code chunks.
         # Python chunks are always one line.
         if (options$engine == "python" && grepl("alt.Chart(", x, fixed = T)) {
+            # iframe_start = "<iframe srcdoc='"
+            # iframe_end = "' width=100% height=400px></iframe>"
+
+            # json_start = '
+            # <html>
+            # <head>
+            #   <script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
+            #   <script src="https://cdn.jsdelivr.net/npm/vega-lite@4.8.1"></script>
+            #   <script src="https://cdn.jsdelivr.net/npm/vega-embed@6"></script>
+            # </head>
+            # <body>
+            #   <div id="vis"></div>
+            #   <script type="text/javascript">
+            #     var spec ='
+            # json_end = ';
+            #     var opt = {"renderer": "canvas", "actions": false};
+            #     vegaEmbed("#vis", spec, opt);
+            #   </script>
+            # </body>
+            # </html>'
+            # # cat(paste(iframe_start, json_start, json_end, iframe_end))
+            # module_dir <- paste(unlist(strsplit(options$fig.path, '_'))[1:2], collapse = '_')
+            module_dir <- unlist(strsplit(options$fig.path, '_'))[1]
+            chapter_dir <- unlist(strsplit(options$fig.path, '_'))[2]
+
+            parent_dir <- file.path('..', '..', '..', '..', 'static', module_dir, 'charts', chapter_dir)
+            if (!dir.exists(parent_dir)) {
+                dir.create(parent_dir, recursive = T)
+            }
+            file_name <- paste(file.path(parent_dir, options$label), '.png', sep='')
+
+            # cat(paste('<iframe src="', file_name, '" width=100% height=400px style=border-width:0;></iframe>', sep=''))
             # This section handles layered plots
             # where a parenthesis needs to be added to the last element of the string
             # so that `to_json()` can be called on the entire plot
@@ -26,9 +58,16 @@ knitr::knit_hooks$set(
                 new_last <- paste0('(', last_command, ')')
                 vector_string[length(vector_string)] <- new_last
                 xx <- paste(vector_string, collapse='\n')
-                c(default_source_hook(x, options), vegawidget::vw_to_svg(exec_with_return(paste(xx, '.to_json()'))))}
+                # c(default_source_hook(x, options), vegawidget::vw_to_svg(exec_with_return(paste(xx, '.to_json()'))))}
+                # c(default_source_hook(x, options), paste(iframe_start, json_start, exec_with_return(paste(xx, '.to_json()')), json_end, iframe_end))}
+                exec_with_return(paste(xx, '.save("', file_name, '")', sep=''))
+                c(default_source_hook(x, options), paste('<iframe src="', file_name, '" width=100% height=400px style=border-width:0;></iframe>', sep=''))}
+
             else {
-                c(default_source_hook(x, options), vegawidget::vw_to_svg(exec_with_return(paste(x, '.to_json()'))))}}
+                # c(default_source_hook(x, options), vegawidget::vw_to_svg(exec_with_return(paste(x, '.to_json()'))))}}
+                # c(default_source_hook(x, options), paste(iframe_start, json_start, exec_with_return(paste(x, '.to_json()')), json_end, iframe_end))}}
+                exec_with_return(paste(x, '.save("', file_name, '")', sep=''))
+                c(default_source_hook(x, options), paste('<iframe src="', file_name, '" width=100% height=400px style=border-width:0;></iframe>', sep=''))}}
         else {
             default_source_hook(x, options)}})
 


### PR DESCRIPTION
It's finally working!

I changed the strategy to saving local files and then referencing them. I also resolved the nested quoting when injecting the HTML section directly in the md-page, but there are issues with the md to HTML converter that the framework uses. It could not resolve long nested quotes correctly such as when including data in the Altair spec, while URLs worked fine.

Instead I switched to saving individual HTML files in the static folder and referencing them in the iframe. Once somewhat obscure gatsby setting is that gatsby by default cannot access HTML files in static when running in dev mode. ll other files work fine, but not HTML.. yeah.... The change to `gatsby-node.js` fixes this by giving [gatsby access to the public folder which is where the static files are copied when the server runs](https://github.com/gatsbyjs/gatsby/issues/17761#issuecomment-533816520).

This now allows us to create plots from data of any size. One minor drawback is that the files are a bit bigger since all the data is included, but we don't work with any large datasets and we will use the URL approach in module 2 for gapminder. The implementation is flexible so that if we want to save plots in another format we can just change the file extension in `slide_setup.R`. This can be made controllable via a chunk option, so if we need that to e.g. save some big data plots as svg/png instead of html, I will add a chunk option for it.

As a bonus this also solves the issue with plots that don't fit, since the iframe becomes scrollable when not fully in view. We can discuss if we still want code hiding, but it at least works now, without adding anything else. Knitting is now also faster with a factor of approximately infinity. Previously I sometimes ended up waiting for minutes for a slide deck and now the htmlfigs are saved in  less than 10 seconds.

I tested and this works on the live server. I did have issues in Firefox, but Chrome works fine and @hfboyce confirmed that Safari does too.