### PR TITLE
Fix typos/errors I made on M2 tests.

### DIFF
--- a/exercises/en/test_02_07b.py
+++ b/exercises/en/test_02_07b.py
@@ -15,7 +15,9 @@ def test():
             "Miles_per_Gallon" in fuel_efficiency_org.encoding.y.shorthand), "Make sure you are using mean of the 'Miles_per_Gallon' as the y-axis encoding."
     assert ((fuel_efficiency_org.encoding.y.field == 'Miles_per_Gallon' and fuel_efficiency.encoding.y.aggregate == 'mean') or 
             fuel_efficiency_org.encoding.y.shorthand in {'mean(Miles_per_Gallon)', 'mean(Miles_per_Gallon):quantitative', 'mean(Miles_per_Gallon):Q'}), "You're very close. Make sure that you are using the mean aggregate for the y-axis encoding."
-    assert (fuel_efficiency_org.encoding.color.field in {'Origin', 'Origin:nominal', 'Origin:N'} or 
-            fuel_efficiency_org.encoding.color.shorthand in {'Origin', 'Origin:nominal', 'Origin:N'}), "Make sure you are using 'Origin' as the color encoding."
+    assert fuel_efficiency_org.encoding.color != alt.utils.schemapi.Undefined and (
+        fuel_efficiency_org.encoding.color.field in {'Origin', 'Origin:nominal', 'Origin:N'} or 
+        fuel_efficiency_org.encoding.color.shorthand in {'Origin', 'Origin:nominal', 'Origin:N'}
+    ), "Make sure you are using 'Origin' as the color encoding."
     assert type(fuel_efficiency_org.title) == str and len(fuel_efficiency_org.title) >= 5, "Make sure you specify a descriptive title for the fuel_efficiency_org plot." 
     __msg__.good("You're correct, well done!")

--- a/exercises/en/test_02_11.py
+++ b/exercises/en/test_02_11.py
@@ -12,11 +12,11 @@ def test():
     assert type(penguin_bar) == type(alt.Chart()), "Your answer is not an Altair Chart object. Check to make sure that you have assigned an alt.Chart object to penguin_bar."
     assert penguin_bar.data.equals(penguins) and penguin_bar.data.shape == (344, 7), "Make sure you are using the penguins dataset."
     assert penguin_bar.mark == 'bar', "Make sure you are using the bar mark type."
-    assert (penguin_bar.encoding.x.shorthand in {'count()', 'count():quantitative', 'count:Q'} or 
-            penguin_bar.encoding.x.field in {'count()', 'count():quantitative', 'count:Q'}), "Make sure you are using 'count()' as the x-axis encoding."
+    assert (penguin_bar.encoding.x.shorthand in {'count()', 'count():quantitative', 'count():Q'} or 
+            penguin_bar.encoding.x.field in {'count()', 'count():quantitative', 'count():Q'}), "Make sure you are using 'count()' as the x-axis encoding."
     assert (penguin_bar.encoding.y.field in {'species', 'species:nominal', 'species:N'} or 
             penguin_bar.encoding.y.shorthand in {'species', 'species:nominal', 'species:N'}), "Make sure you are using 'species' as the y-axis encoding."
-    assert penguin_bar.encoding.y.sort != alt.utils.schemapi.Undefined, "Make sure you are specify the sort argument for the y-axis encoding."
+    assert penguin_bar.encoding.y.sort != alt.utils.schemapi.Undefined, "Make sure you specify the sort argument for the y-axis encoding."
     assert type(penguin_bar.title) == str and len(penguin_bar.title) >= 5, "Make sure you specify a descriptive title for the penguin_bar plot."
     assert penguin_bar.height == 150, "Make sure you specify the plot height of 150."
     assert penguin_bar.width == 300, "Make sure you specify the plot width of 300." 

--- a/exercises/en/test_02_12.py
+++ b/exercises/en/test_02_12.py
@@ -15,8 +15,8 @@ def test():
     assert (penguin_hist.encoding.x.shorthand in {'flipper_length_mm', 'flipper_length_mm:quantitative', 'flipper_length_mm:Q'} or 
             penguin_hist.encoding.x.field in {'flipper_length_mm', 'flipper_length_mm:quantitative', 'flipper_length_mm:Q'}), "Make sure you are using 'flipper_length_mm' as the x-axis encoding."
     assert penguin_hist.encoding.x.bin != alt.utils.schemapi.Undefined, "Make sure you are specifying the bin argument for the x-axis encoding for the histogram."
-    assert (penguin_hist.encoding.y.field in {'count()', 'count():quantitative', 'count:Q'} or 
-            penguin_hist.encoding.y.shorthand in {'count()', 'count():quantitative', 'count:Q'}), "Make sure you are using 'count()' as the y-axis encoding."
+    assert (penguin_hist.encoding.y.field in {'count()', 'count():quantitative', 'count():Q'} or 
+            penguin_hist.encoding.y.shorthand in {'count()', 'count():quantitative', 'count():Q'}), "Make sure you are using 'count()' as the y-axis encoding."
     assert type(penguin_hist.title) == str and len(penguin_hist.title) >= 5, "Make sure you specify a descriptive title for the penguin_hist plot."
     assert penguin_hist.height == 150, "Make sure you specify the plot height of 150."
     assert penguin_hist.width == 300, "Make sure you specify the plot width of 300." 

--- a/exercises/en/test_02_16.py
+++ b/exercises/en/test_02_16.py
@@ -14,11 +14,11 @@ def test():
     assert penguin_facet.facet.column in {'species', 'species:nominal', 'species:N'}, "Make sure you are facetting by 'species' for the columns."
     assert penguin_facet.facet.row in {'island', 'island:nominal', 'island:N'}, "Make sure you are facetting by 'island' for the rows."
     assert penguin_facet.spec.mark == 'bar', "Make sure you are using the bar mark type."
-    assert (penguin_facet.spec.encoding.x.shorthand in {'body_mass_g', 'body_mass_g:quantitative', 'body_mass_g;Q'} or 
-            penguin_facet.spec.encoding.x.field in {'body_mass_g', 'body_mass_g:quantitative', 'body_mass_g;Q'}), "Make sure you are using 'body_mass_g' as the x-axis encoding."
+    assert (penguin_facet.spec.encoding.x.shorthand in {'body_mass_g', 'body_mass_g:quantitative', 'body_mass_g:Q'} or 
+            penguin_facet.spec.encoding.x.field in {'body_mass_g', 'body_mass_g:quantitative', 'body_mass_g:Q'}), "Make sure you are using 'body_mass_g' as the x-axis encoding."
     assert penguin_facet.spec.encoding.x.bin != alt.utils.schemapi.Undefined, "Make sure you are specifying the bin argument for the x-axis encoding for the histogram."
-    assert (penguin_facet.spec.encoding.y.field in {'count()', 'count():quantitative', 'count:Q'} or 
-            penguin_facet.spec.encoding.y.shorthand in {'count()', 'count():quantitative', 'count:Q'}), "Make sure you are using 'count()' as the y-axis encoding."
+    assert (penguin_facet.spec.encoding.y.field in {'count()', 'count():quantitative', 'count():Q'} or 
+            penguin_facet.spec.encoding.y.shorthand in {'count()', 'count():quantitative', 'count():Q'}), "Make sure you are using 'count()' as the y-axis encoding."
     assert type(penguin_facet.spec.title) == str and len(penguin_facet.spec.title) >= 5, "Make sure you specify a descriptive title for the penguin_bar plot."
     assert penguin_facet.spec.height == 100, "Make sure you specify the plot height of 100."
     assert penguin_facet.spec.width == 150, "Make sure you specify the plot width of 150."


### PR DESCRIPTION
Fix minor typos, make `test_02_07b` more robust (give better error message) in case students don't specify the color encoding at all. 