### PR TITLE
Add C5 tests.

### DIFF
--- a/chapters/en/module5.md
+++ b/chapters/en/module5.md
@@ -352,7 +352,7 @@ Fill in the blanks in the code below so that the following gets accomplished:
 - Display the base plot and take a look at what it's communicating.
 - Create text by using `mark_text()` and save this in an object named `text`. It should have the same x and y mapping as the base plot but this time you want to make sure the count is displayed on the side of each species bar. Make sure it's centered in alignment and located at `dx=10`.
 - After observing the plot create and object named `penguin_title` using `.TitleParams()`. In this method, you will need to specify an insightful title, and subtitle, give the title a fontsize of 18, and set the subtitle colour to `firebrick`.
-- Remove emove the grey box outlining the entire figure by setting the argument `strokeWidth` in the `.configure_view()` method. 
+- Remove the grey box outlining the entire figure by setting the argument `strokeWidth` in the `.configure_view()` method.
 
 <codeblock id="05_07">
 
@@ -986,14 +986,14 @@ Tasks:
 Fill in the blanks in the code below so that the following gets accomplished:
 
 
-- In a plot named `temp_plot`, use the data source `temps_df` to make a scatter plot (`mark_point`) with points that are size 50.
+- In a plot named `temp_plot`, use the data source `temps_df` to make a scatter plot (`mark_circle`) with points that are size 50.
 - Map the date on the x-axis and the total rainfall levels on the y-axis. 
 - Map the mean temperature to a colour channel and select an appropriate [colour scheme](https://vega.github.io/vega/docs/schemes/). Is a diverging or sequential scheme more appropriate? What is an appropriate mid-point value?
 - Make sure you are giving the channels all proper labels and the plot a title. 
 
 <codeblock id="05_19">
 
-- Are you using `mark_point(size=50)`?
+- Are you using `mark_circle(size=50)`?
 - Are you setting `alt.X('date', title="Date"))`?
 - Are you setting `alt.Y('total_rain_mm',title='rainfall total for the month (mm)')`?
 - In the  plot, are you coding `alt.Color('mean_temp', title=' Mean Temperature', scale=alt.Scale(scheme='blueorange', domainMid=0))`?
@@ -1175,7 +1175,7 @@ Fill in the blanks in the code below so that the following gets accomplished:
 - Map the month on the y-axis and the sum of all the precipitation for each month on the x-axis. Print your chart first and examine which month has the most precipitation.
 - Color `rain_plot` by designating a different colour bar to the month with the highest rainfall.
 - Make sure you are giving the x-axis an appropriate label and the plot a title. 
-- In a second plot named `text_plot`, add text to each bar that shows the aggregate precipitation for each month and format it so it includes integer values only. Make sure it is aligned to the left and located 4 units to the right of the bar (use `dx` for this).  Set the text colour as black.
+- In a second plot named `text_plot`, add text to each bar that shows the aggregate precipitation for each month and format it so it includes integer values only. Make sure it is aligned to the left and located 5 units to the right of the bar (use `dx` for this).  Set the text colour as black.
 
 <codeblock id="05_23">
 

--- a/exercises/en/exc_05_11a.py
+++ b/exercises/en/exc_05_11a.py
@@ -5,10 +5,10 @@ import pandas as pd
 income_df = pd.read_csv('data/income_expenditure.csv')
 
 income_plot = alt.Chart(income_df).mark_circle(____).encode(
-    alt.Y('tot_income',
+    alt.X('tot_income',
           axis=____,
           title=____),
-    alt.X('education_expenditure',
+    alt.Y('education_expenditure',
           axis=____,
           title=____)
 ).properties(title=____)

--- a/exercises/en/exc_05_23.py
+++ b/exercises/en/exc_05_23.py
@@ -5,7 +5,7 @@ from calendar import month_name
 temps_df = pd.read_csv('data/temperature.csv', parse_dates=['date'])
 temps_df = temps_df.assign(month=temps_df['date'].dt.month_name())
 
-top_month = temps_df.groupby('month')['total_precipitate_mm'].sum().idxmax()
+top_month = temps_df.groupby('month')['total_rain_mm'].sum().idxmax()
 
 rain_plot = alt.Chart(temps_df).____().encode(
     alt.X('sum(total_rain_mm)',

--- a/exercises/en/exc_income_exp.py
+++ b/exercises/en/exc_income_exp.py
@@ -3,5 +3,4 @@ import pandas as pd
 
 
 income_df = pd.read_csv('data/income_expenditure.csv')
-
 income_df.head()

--- a/exercises/en/exc_temperatures.py
+++ b/exercises/en/exc_temperatures.py
@@ -3,5 +3,4 @@ import pandas as pd
 
 
 temps_df = pd.read_csv('data/temperature.csv', parse_dates=['date'])
-print(temps_df.iloc[:5, :5])
-print(temps_df.iloc[:5, 5:])
+temps_df.info()

--- a/exercises/en/exc_temperatures2.py
+++ b/exercises/en/exc_temperatures2.py
@@ -4,5 +4,4 @@ import pandas as pd
 
 temps_df = pd.read_csv('data/temperature.csv', parse_dates=['date'])
 temps_df = temps_df.assign(month=temps_df['date'].dt.month_name())
-print(temps_df.iloc[:5, :5])
-print(temps_df.iloc[:5, 5:])
+temps_df.info()

--- a/exercises/en/solution_05_19.py
+++ b/exercises/en/solution_05_19.py
@@ -8,7 +8,7 @@ temp_plot = alt.Chart(temps_df).mark_circle(size=50).encode(
     alt.X('date', 
         title="Date"),
     alt.Y('total_rain_mm',
-        title='rainfall total for the month (mm)'),
+        title='Total rainfall for the month (mm)'),
     alt.Color('mean_temp',
         title=' Mean Temperature',
         scale=alt.Scale(scheme='blueorange', domainMid=0))

--- a/exercises/en/solution_05_23.py
+++ b/exercises/en/solution_05_23.py
@@ -5,7 +5,7 @@ from calendar import month_name
 temps_df = pd.read_csv('data/temperature.csv', parse_dates=['date'])
 temps_df = temps_df.assign(month=temps_df['date'].dt.month_name())
 
-top_month = temps_df.groupby('month')['total_precipitate_mm'].sum().idxmax()
+top_month = temps_df.groupby('month')['total_rain_mm'].sum().idxmax()
 
 rain_plot = alt.Chart(temps_df).mark_bar().encode(
     alt.X('sum(total_rain_mm)',
@@ -15,7 +15,7 @@ rain_plot = alt.Chart(temps_df).mark_bar().encode(
                         alt.value('darkslateblue'),
                         alt.value('powderblue'))
 ).properties(
-    title='Between 2009-2012, May had the greatest total precipitation collectively')
+    title='Between 2009-2012, May had the greatest total rainfall collectively')
 
 text_plot = rain_plot.mark_text(align='left', dx=4).encode(
     text=alt.Text('sum(total_rain_mm)', format='d'),

--- a/exercises/en/solution_05_23.py
+++ b/exercises/en/solution_05_23.py
@@ -17,7 +17,7 @@ rain_plot = alt.Chart(temps_df).mark_bar().encode(
 ).properties(
     title='Between 2009-2012, May had the greatest total rainfall collectively')
 
-text_plot = rain_plot.mark_text(align='left', dx=4).encode(
+text_plot = rain_plot.mark_text(align='left', dx=5).encode(
     text=alt.Text('sum(total_rain_mm)', format='d'),
     color = alt.value('black'))
 

--- a/exercises/en/solution_05_23.py
+++ b/exercises/en/solution_05_23.py
@@ -17,7 +17,7 @@ rain_plot = alt.Chart(temps_df).mark_bar().encode(
 ).properties(
     title='Between 2009-2012, May had the greatest total precipitation collectively')
 
-text_plot = rain_plot.mark_text(align='left', dx=5).encode(
+text_plot = rain_plot.mark_text(align='left', dx=4).encode(
     text=alt.Text('sum(total_rain_mm)', format='d'),
     color = alt.value('black'))
 

--- a/exercises/en/solution_income_exp.py
+++ b/exercises/en/solution_income_exp.py
@@ -3,5 +3,4 @@ import pandas as pd
 
 
 income_df = pd.read_csv('data/income_expenditure.csv')
-
 income_df.head()

--- a/exercises/en/solution_temperatures.py
+++ b/exercises/en/solution_temperatures.py
@@ -3,5 +3,4 @@ import pandas as pd
 
 
 temps_df = pd.read_csv('data/temperature.csv', parse_dates=['date'])
-print(temps_df.iloc[:5, :5])
-print(temps_df.iloc[:5, 5:])
+temps_df.info()

--- a/exercises/en/solution_temperatures2.py
+++ b/exercises/en/solution_temperatures2.py
@@ -4,5 +4,4 @@ import pandas as pd
 
 temps_df = pd.read_csv('data/temperature.csv', parse_dates=['date'])
 temps_df = temps_df.assign(month=temps_df['date'].dt.month_name())
-print(temps_df.iloc[:5, :5])
-print(temps_df.iloc[:5, 5:])
+temps_df.info()

--- a/exercises/en/test_05_07.py
+++ b/exercises/en/test_05_07.py
@@ -1,0 +1,44 @@
+def test():
+    # Here we can either check objects created in the solution code, or the
+    # string value of the solution, available as __solution__. A helper for
+    # printing formatted messages is available as __msg__. See the testTemplate
+    # in the meta.json for details.
+    # If an assertion fails, the message will be displayed
+
+    assert not text is None, "Your answer for text does not exist. Have you assigned the added text to the correct variable name?"
+    assert type(text) == alt.Chart, "text does not appear to be an Altair Chart object. Have you assigned the Altair Chart object for added text to the correct variable?"
+    assert text.mark != alt.utils.schemapi.Undefined and (
+        text.mark.align == 'center' and
+        text.mark.dx == 10 and
+        text.mark.type == 'text'
+    ), "Make sure you are using mark_text and specify `center` alignment and location at dx=10."
+    assert text.encoding.x != alt.utils.schemapi.Undefined and (
+        text.encoding.x.field in {'count()', 'count():quantitative', 'count():Q'} or
+        text.encoding.x.shorthand in {'count()', 'count():quantitative', 'count():Q'}
+    ), "Make sure you are using 'count()' as the x-axis encoding for the added text."
+    assert text.encoding.y != alt.utils.schemapi.Undefined and (
+        text.encoding.y.field in {'species', 'species:nominal', 'species:N'} or
+        text.encoding.y.shorthand in {'species', 'species:nominal', 'species:N'}
+    ), "Make sure you are using 'species' as the y-axis encoding for the added text."
+    assert text.encoding.text != alt.utils.schemapi.Undefined and (
+        text.encoding.text.field in {'count()', 'count():quantitative', 'count():Q'} or
+        text.encoding.text.shorthand in {'count()', 'count():quantitative', 'count():Q'}
+    ), "Make sure you are using 'count()' as the text encoding for the added text."
+
+    assert not penguin_title is None, "Your answer for penguin_title does not exist. Have you assigned the title and subtitle formatting to the correct variable name?"
+    assert type(penguin_title) == alt.TitleParams, "penguin_title does not appear to be an Altair TitleParams object. Have you assigned the Altair TitleParams object for title and subtitle formatting to the correct variable?"
+    assert penguin_title.fontSize == 18, "Can you set fontSize of 18 for penguin_title?"
+    assert penguin_title.subtitleColor == 'firebrick', "Can you set subtitleColor to 'firebrick' for penguin_title?"
+    assert type(penguin_title.text) == str and len(penguin_title.text) >= 5, "Make sure you specify a descriptive title for penguin_title. Hint: title text for penguin_title can be specified using text argument, which is also the first argument."
+    assert not penguin_title.text.islower(), "Make sure the title for penguin_title is capitalized."
+    assert type(penguin_title.subtitle) == str and len(penguin_title.subtitle) >= 5, "Make sure you specify a descriptive subtitle for penguin_title."
+    assert not penguin_title.subtitle.islower(), "Make sure the subtitle for penguin_title is capitalized."
+
+    assert not formatted_plot is None, "Your answer for formatted_plot does not exist. Have you assigned the final formatted plot to the correct variable name?"
+    assert type(formatted_plot) == alt.LayerChart, "formatted_plot does not appear to be an Altair LayerChart object. Have you assigned the LayerChart object for formatted plot to the correct variable?"
+    assert (
+        formatted_plot.config != alt.utils.schemapi.Undefined and 
+        formatted_plot.config.view != alt.utils.schemapi.Undefined and
+        formatted_plot.config.view.strokeWidth == 0
+    ), "Make sure to remove the grey box outline from the figure. Hint: setting the strokeWidth argument to 0 in the .configure_view() method hides the outline."
+    __msg__.good("You're correct, well done!")

--- a/exercises/en/test_05_11a.py
+++ b/exercises/en/test_05_11a.py
@@ -1,0 +1,36 @@
+def test():
+    # Here we can either check objects created in the solution code, or the
+    # string value of the solution, available as __solution__. A helper for
+    # printing formatted messages is available as __msg__. See the testTemplate
+    # in the meta.json for details.
+    # If an assertion fails, the message will be displayed
+
+    assert not income_plot is None, "Your answer for income_plot does not exist. Have you assigned the plot to the correct variable name?"
+    assert type(income_plot) == alt.Chart, "income_plot does not appear to be an Altair Chart object. Have you assigned the Altair Chart object for the plot to the correct variable?"
+    assert income_plot.mark != alt.utils.schemapi.Undefined and (
+        income_plot.mark.opacity == 0.5 and
+        income_plot.mark.size == 10 and
+        income_plot.mark.type == 'circle'
+    ), "Make sure you are using mark_circle and set opacity to 0.5 and size to 10."
+
+    assert income_plot.encoding.x.axis != alt.utils.schemapi.Undefined and (
+        income_plot.encoding.x.axis.format in {'s', '~s'}
+    ), "Make sure you are specifying that the axis values for x-axis encoding have SI units. Hint: set format argument to 's' in alt.Axis()"
+    assert type(income_plot.encoding.x.title) == str and not income_plot.encoding.x.title.islower(), "Make sure you give a descriptive axis title with appropriate capitalization for the x-axis encoding."
+    assert (
+        "₱" in income_plot.encoding.x.title or
+        "PHP" in income_plot.encoding.x.title
+    ), "Make sure to include the unit for the x-axis title (Hint: 'tot_income' is measured in 'PHP' currency."
+
+    assert income_plot.encoding.y.axis != alt.utils.schemapi.Undefined and (
+        income_plot.encoding.y.axis.format in {'s', '~s'}
+    ), "Make sure you are specifying that the axis values for y-axis encoding have SI units. Hint: set format argument to 's' in alt.Axis()"
+    assert type(income_plot.encoding.y.title) == str and not income_plot.encoding.y.title.islower(), "Make sure you give a descriptive axis title with appropriate capitalization for the y-axis encoding."
+    assert (
+        "₱" in income_plot.encoding.y.title or
+        "PHP" in income_plot.encoding.y.title
+    ), "Make sure to include the unit for the y-axis title (Hint: 'education_expenditure' is measured in 'PHP' currency."
+
+    assert type(income_plot.title) == str and len(income_plot.title) >= 5, "Make sure you specify a descriptive title for income_plot."
+    assert not income_plot.title.islower(), "Make sure the plot title is capitalized."
+    __msg__.good("You're correct, well done!")

--- a/exercises/en/test_05_11b.py
+++ b/exercises/en/test_05_11b.py
@@ -1,0 +1,42 @@
+def test():
+    # Here we can either check objects created in the solution code, or the
+    # string value of the solution, available as __solution__. A helper for
+    # printing formatted messages is available as __msg__. See the testTemplate
+    # in the meta.json for details.
+    # If an assertion fails, the message will be displayed
+
+    assert not income_log_plot is None, "Your answer for income_log_plot does not exist. Have you assigned the plot to the correct variable name?"
+    assert type(income_log_plot) == alt.Chart, "income_log_plot does not appear to be an Altair Chart object. Have you assigned the Altair Chart object for the plot to the correct variable?"
+    assert income_log_plot.mark != alt.utils.schemapi.Undefined and (
+        income_log_plot.mark.opacity == 0.5 and
+        income_log_plot.mark.size == 10 and
+        income_log_plot.mark.type == 'circle'
+    ), "Make sure you are using mark_circle and set opacity to 0.5 and size to 10."
+
+    assert income_log_plot.encoding.x.axis != alt.utils.schemapi.Undefined and (
+        income_log_plot.encoding.x.axis.format in {'s', '~s'}
+    ), "Make sure you are specifying that the axis values for x-axis encoding have SI units. Hint: set format argument to 's' in alt.Axis()"
+    assert type(income_log_plot.encoding.x.title) == str and not income_log_plot.encoding.x.title.islower(), "Make sure you give a descriptive axis title with appropriate capitalization for the x-axis encoding."
+    assert (
+        "₱" in income_log_plot.encoding.x.title or
+        "PHP" in income_log_plot.encoding.x.title
+    ), "Make sure to include the unit for the x-axis title (Hint: 'tot_income' is measured in 'PHP' currency."
+    assert income_log_plot.encoding.x.scale != alt.utils.schemapi.Undefined and (
+        income_log_plot.encoding.x.scale.type == 'symlog'
+    ), "Make sure to transform the x-axis scale by setting type argument for alt.Scale() to appropriate transformation from the multiple choice question above."
+
+    assert income_log_plot.encoding.y.axis != alt.utils.schemapi.Undefined and (
+        income_log_plot.encoding.y.axis.format in {'s', '~s'}
+    ), "Make sure you are specifying that the axis values for y-axis encoding have SI units. Hint: set format argument to 's' in alt.Axis()"
+    assert type(income_log_plot.encoding.y.title) == str and not income_log_plot.encoding.y.title.islower(), "Make sure you give a descriptive axis title with appropriate capitalization for the y-axis encoding."
+    assert (
+        "₱" in income_log_plot.encoding.y.title or
+        "PHP" in income_log_plot.encoding.y.title
+    ), "Make sure to include the unit for the y-axis title (Hint: 'education_expenditure' is measured in 'PHP' currency."
+    assert income_log_plot.encoding.y.scale != alt.utils.schemapi.Undefined and (
+        income_log_plot.encoding.y.scale.type == 'symlog'
+    ), "Make sure to transform the y-axis scale by setting type argument for alt.Scale() to appropriate transformation from the multiple choice question above."
+
+    assert type(income_log_plot.title) == str and len(income_log_plot.title) >= 5, "Make sure you specify a descriptive title for income_log_plot."
+    assert not income_log_plot.title.islower(), "Make sure the plot title is capitalized."
+    __msg__.good("You're correct, well done!")

--- a/exercises/en/test_05_15.py
+++ b/exercises/en/test_05_15.py
@@ -1,0 +1,47 @@
+def test():
+    # Here we can either check objects created in the solution code, or the
+    # string value of the solution, available as __solution__. A helper for
+    # printing formatted messages is available as __msg__. See the testTemplate
+    # in the meta.json for details.
+    # If an assertion fails, the message will be displayed
+
+    assert not colour_plot is None, "Your answer for colour_plot does not exist. Have you assigned the plot to the correct variable name?"
+    assert type(colour_plot) == alt.Chart, "colour_plot does not appear to be an Altair Chart object. Have you assigned the Altair Chart object for the plot to the correct variable?"
+    assert colour_plot.mark != alt.utils.schemapi.Undefined and (
+        colour_plot.mark.size == 10 and
+        colour_plot.mark.type == 'point'
+    ), "Make sure you are using mark_point and set size to 10."
+
+    assert colour_plot.encoding.x.scale != alt.utils.schemapi.Undefined and (
+        colour_plot.encoding.x.scale.domain != alt.utils.schemapi.Undefined
+    ), "Are you selecting an appropriate domain for x-axis? Hint: set domain argument in alt.Scale()"
+    assert type(colour_plot.encoding.x.title) == str and not colour_plot.encoding.x.title.islower(), "Make sure you give a descriptive axis title with appropriate capitalization for the x-axis encoding."
+    assert (
+        "mm" in colour_plot.encoding.x.title
+    ), "Make sure to include the unit for the x-axis title (Hint: 'flipper_length_mm' is measured in 'mm'."
+
+    assert colour_plot.encoding.y.scale != alt.utils.schemapi.Undefined and (
+        colour_plot.encoding.y.scale.domain != alt.utils.schemapi.Undefined
+    ), "Are you selecting an appropriate domain for y-axis? Hint: set domain argument in alt.Scale()"
+    assert type(colour_plot.encoding.y.title) == str and not colour_plot.encoding.y.title.islower(), "Make sure you give a descriptive axis title with appropriate capitalization for the y-axis encoding."
+    assert (
+        "g" in colour_plot.encoding.y.title
+    ), "Make sure to include the unit for the y-axis title (Hint: 'body_mass_g' is measured in 'g'."
+
+    assert colour_plot.encoding.color != alt.utils.schemapi.Undefined and (
+        colour_plot.encoding.color.field in {'species', 'species:nominal', 'species:N'} or
+        colour_plot.encoding.color.shorthand in {'species', 'species:nominal', 'species:N'}
+    ), "Make sure you are using 'species' as the color encoding."
+    assert type(colour_plot.encoding.color.title) == str and not colour_plot.encoding.color.title.islower(), "Make sure you give a descriptive legend title with appropriate capitalization for the color encoding."
+    assert colour_plot.encoding.color.scale != alt.utils.schemapi.Undefined and (
+        colour_plot.encoding.color.scale.scheme != alt.utils.schemapi.Undefined
+    ), "Are you selecting an appropriate colour scheme for color encoding? Hint: set scheme argument in alt.Scale() for color encoding"
+    
+    assert colour_plot.encoding.shape != alt.utils.schemapi.Undefined and (
+        colour_plot.encoding.shape.field in {'species', 'species:nominal', 'species:N'} or
+        colour_plot.encoding.shape.shorthand in {'species', 'species:nominal', 'species:N'}
+    ), "Make sure you are using 'species' as the shape encoding."
+    
+    assert type(colour_plot.title) == str and len(colour_plot.title) >= 5, "Make sure you specify a descriptive title for colour_plot."
+    assert not colour_plot.title.islower(), "Make sure the plot title is capitalized."
+    __msg__.good("You're correct, well done!")

--- a/exercises/en/test_05_19.py
+++ b/exercises/en/test_05_19.py
@@ -1,0 +1,42 @@
+def test():
+    # Here we can either check objects created in the solution code, or the
+    # string value of the solution, available as __solution__. A helper for
+    # printing formatted messages is available as __msg__. See the testTemplate
+    # in the meta.json for details.
+    # If an assertion fails, the message will be displayed
+
+    assert not temp_plot is None, "Your answer for temp_plot does not exist. Have you assigned the plot to the correct variable name?"
+    assert type(temp_plot) == alt.Chart, "temp_plot does not appear to be an Altair Chart object. Have you assigned the Altair Chart object for the plot to the correct variable?"
+    assert temp_plot.mark != alt.utils.schemapi.Undefined and (
+        temp_plot.mark.size == 50 and
+        temp_plot.mark.type == 'circle'
+    ), "Make sure you are using mark_circle and set size to 50."
+
+    assert (
+        temp_plot.encoding.x.field in {'date', 'date:temporal', 'date:T'} or
+        temp_plot.encoding.x.shorthand in {'date', 'date:temporal', 'date:T'}
+    ), "Make sure you are using 'date' as the x-axis encoding."
+    assert type(temp_plot.encoding.x.title) == str and not temp_plot.encoding.x.title.islower(), "Make sure you give a descriptive axis title with appropriate capitalization for the x-axis encoding."
+
+    assert (
+        temp_plot.encoding.y.field in {'total_rain_mm', 'total_rain_mm:quantitative', 'total_rain_mm:Q'} or
+        temp_plot.encoding.y.shorthand in {'total_rain_mm', 'total_rain_mm:quantitative', 'total_rain_mm:Q'}
+    ), "Make sure you are using 'total_rain_mm' as the y-axis encoding."
+    assert type(temp_plot.encoding.y.title) == str and not temp_plot.encoding.y.title.islower(), "Make sure you give a descriptive axis title with appropriate capitalization for the y-axis encoding."
+    assert (
+        "mm" in temp_plot.encoding.y.title
+    ), "Make sure to include the unit for the y-axis title (Hint: 'total_rain_mm' is measured in 'mm'."
+
+    assert temp_plot.encoding.color != alt.utils.schemapi.Undefined and (
+        temp_plot.encoding.color.field in {'mean_temp', 'mean_temp:quantitative', 'mean_temp:Q'} or
+        temp_plot.encoding.color.shorthand in {'mean_temp', 'mean_temp:quantitative', 'mean_temp:Q'}
+    ), "Make sure you are using 'mean_temp' as the color encoding."
+    assert type(temp_plot.encoding.color.title) == str and not temp_plot.encoding.color.title.islower(), "Make sure you give a descriptive legend title with appropriate capitalization for the color encoding."
+    assert temp_plot.encoding.color.scale != alt.utils.schemapi.Undefined and (
+        temp_plot.encoding.color.scale.scheme != alt.utils.schemapi.Undefined and
+        temp_plot.encoding.color.scale.domainMid != alt.utils.schemapi.Undefined
+    ), "Are you selecting an appropriate colour scheme and specifying mid-point value for color encoding? Hint: set scheme argument and domainMid argument in alt.Scale() for color encoding"
+    
+    assert type(temp_plot.title) == str and len(temp_plot.title) >= 5, "Make sure you specify a descriptive title for temp_plot."
+    assert not temp_plot.title.islower(), "Make sure the plot title is capitalized."
+    __msg__.good("You're correct, well done!")

--- a/exercises/en/test_05_23.py
+++ b/exercises/en/test_05_23.py
@@ -1,0 +1,59 @@
+def test():
+    # Here we can either check objects created in the solution code, or the
+    # string value of the solution, available as __solution__. A helper for
+    # printing formatted messages is available as __msg__. See the testTemplate
+    # in the meta.json for details.
+    # If an assertion fails, the message will be displayed
+
+    assert not rain_plot is None, "Your answer for rain_plot does not exist. Have you assigned the plot to the correct variable name?"
+    assert type(rain_plot) == alt.Chart, "rain_plot does not appear to be an Altair Chart object. Have you assigned the Altair Chart object for the plot to the correct variable?"
+    assert rain_plot.mark == 'bar', "Make sure you are using mark_bar for rain_plot."
+
+    assert type(rain_plot.encoding.x.title) == str and not rain_plot.encoding.x.title.islower(), "Make sure you give a descriptive axis title with appropriate capitalization for the x-axis encoding."
+    assert (
+        "mm" in rain_plot.encoding.x.title
+    ), "Make sure to include the unit for the x-axis title (Hint: 'total_rain_mm' is measured in 'mm'."
+
+    assert (
+        rain_plot.encoding.color != alt.utils.schemapi.Undefined and
+        rain_plot.encoding.color.condition != alt.utils.schemapi.Undefined
+    ), "Make sure you use alt.Condition in color encoding to designate a different colour to the month with the highest rainfall."
+    assert(
+        "datum.month" in str(rain_plot.encoding.color.condition.test) and (
+            "top_month" in str(rain_plot.encoding.color.condition.test) or
+            "May" in str(rain_plot.encoding.color.condition.test)
+        )
+    ), "Make sure you use correct condition in color encoding to designate a different colour to the month with the highest rainfall. Hint: you can compare alt.datum.month with the top_month defined above."
+    assert rain_plot.encoding.color.value != rain_plot.encoding.color.condition.value, "Make sure you designate different colours to month with the highest rainfall and other months."
+    
+    assert type(rain_plot.title) == str and len(rain_plot.title) >= 5, "Make sure you specify a descriptive title for rain_plot."
+    assert not rain_plot.title.islower(), "Make sure the plot title is capitalized."
+
+    assert not text_plot is None, "Your answer for text_plot does not exist. Have you assigned the plot annotation object to the correct variable name?"
+    assert type(text_plot) == alt.Chart, "text_plot does not appear to be an Altair Chart object. Have you assigned the Altair Chart object for the plot annotation to the correct variable?"
+    assert text_plot.mark != alt.utils.schemapi.Undefined and (
+        text_plot.mark.align== 'left' and
+        text_plot.mark.dx== 4 and
+        text_plot.mark.type == 'text'
+    ), "Make sure you are using mark_text and specify `left` alignment and location at dx=4 for text_plot."
+    assert (
+        text_plot.encoding.text != alt.utils.schemapi.Undefined and
+        text_plot.encoding.text.format == 'd' and (
+            (
+                text_plot.encoding.text.field in {'sum(total_rain_mm)', 'sum(total_rain_mm):quantitative', 'sum(total_rain_mm):Q'} or
+                text_plot.encoding.text.shorthand in {'sum(total_rain_mm)', 'sum(total_rain_mm):quantitative', 'sum(total_rain_mm):Q'}
+            ) or 
+            (
+                text_plot.encoding.text.aggregate == 'sum' and (
+                    text_plot.encoding.text.field in {'total_rain_mm', 'total_rain_mm:quantitative', 'total_rain_mm:Q'} or
+                    text_plot.encoding.text.shorthand in {'total_rain_mm', 'total_rain_mm:quantitative', 'total_rain_mm:Q'}
+                )
+            )
+        )
+    ), "Make sure you are the text encoding for text_plot displays the aggregate precipitation for each month, formatted to show integer values only." 
+
+    assert text_plot.encoding.color != alt.utils.schemapi.Undefined and (
+        text_plot.encoding.color.value == 'black'
+    ), "Make sure you are setting the text color for text annotation to black. Hint: remember when setting color to a specific color, you have to use alt.value()."
+
+    __msg__.good("You're correct, well done!")

--- a/exercises/en/test_05_23.py
+++ b/exercises/en/test_05_23.py
@@ -33,7 +33,7 @@ def test():
     assert type(text_plot) == alt.Chart, "text_plot does not appear to be an Altair Chart object. Have you assigned the Altair Chart object for the plot annotation to the correct variable?"
     assert text_plot.mark != alt.utils.schemapi.Undefined and (
         text_plot.mark.align== 'left' and
-        text_plot.mark.dx== 4 and
+        text_plot.mark.dx== 5 and
         text_plot.mark.type == 'text'
     ), "Make sure you are using mark_text and specify `left` alignment and location at dx=4 for text_plot."
     assert (


### PR DESCRIPTION
`Exc_05_07.py` instructions

> - Remove emove the grey box outlining the entire figure by setting the argument `strokeWidth` in the `.configure_view()` method.

should be 

- Remove the grey box outlining the entire figure by setting the argument `strokeWidth` in the `.configure_view()` method.

`Exc_05_19.py` instructions

> - In a plot named `temp_plot`, use the data source temps_df to make a scatter plot (`mark_point`) with points that are size 50.

I think instructions should say “`mark_circle`” instead of “`mark_point`”.

Please let me know if there are any suggestions, thanks!