### PR TITLE
Add M6 content tests.

### DIFF
--- a/exercises/en/exc_06_12.py
+++ b/exercises/en/exc_06_12.py
@@ -51,4 +51,6 @@ titles = alt.TitleParams(
 
 
 # Organize the plots above so it looks like the example provided above.
-(____).____(title=titles)
+combined_plot = (____).____(title=titles)
+
+combined_plot

--- a/exercises/en/solution_06_12.py
+++ b/exercises/en/solution_06_12.py
@@ -51,5 +51,7 @@ titles = alt.TitleParams(
 
 
 # Organize the plots above so it looks like the example provided above.
-(mass_density_plot & (mass_boxplot | penguin_heatmap) & culmen_facet_plot
+combined_plot = (mass_density_plot & (mass_boxplot | penguin_heatmap) & culmen_facet_plot
 ).properties(title=titles)
+
+combined_plot

--- a/exercises/en/test_06_08a.py
+++ b/exercises/en/test_06_08a.py
@@ -1,0 +1,25 @@
+def test():
+    # Here we can either check objects created in the solution code, or the
+    # string value of the solution, available as __solution__. A helper for
+    # printing formatted messages is available as __msg__. See the testTemplate
+    # in the meta.json for details.
+    # If an assertion fails, the message will be displayed
+
+    assert not world_df is None, "Your answer for world_df does not exist. Have you loaded the TopoJSON data to the correct variable name?"
+    assert "topo_feature" in __solution__, "The loaded data should be in TopoJSON format. In order to read TopoJSON file correctly, you need to use the alt.topo_feature() function."
+    assert type(world_df) == alt.UrlData, "world_df does not appear to be an Altair UrlData object. Have you assigned the Altair UrlData object for the TopoJSON data to the correct variable?"
+    assert world_df.url == data.world_110m.url, "Make sure you are loading the data from correct url."
+    assert (world_df.format !=  alt.utils.schemapi.Undefined and 
+            world_df.format.type == 'topojson'
+    ), "The loaded data should be in TopoJSON format. In order to read TopoJSON file correctly, you need to use the alt.topo_feature() function."
+    assert world_df.format.feature == "countries", "Make sure to specify 'countries' feature when loading the TopoJSON file using alt.topo_feature()."
+
+    assert not world_plot is None, "Your answer for world_plot does not exist. Have you assigned the plot to the correct variable name?"
+    assert type(world_plot) == alt.Chart, "world_plot does not appear to be an Altair Chart object. Have you assigned the Altair Chart object for the plot to the correct variable?"
+    assert world_plot.mark == 'geoshape', "Make sure you are using mark_geoshape for world_plot."
+
+    assert world_plot.projection != alt.utils.schemapi.Undefined and (
+        world_plot.projection.type == 'equalEarth'
+    ), "Make sure you use 'equalEarth' projection. Hint: you can use .project() method with type argument to specify projection type."
+
+    __msg__.good("You're correct, well done!")

--- a/exercises/en/test_06_08a.py
+++ b/exercises/en/test_06_08a.py
@@ -8,7 +8,7 @@ def test():
     assert not world_df is None, "Your answer for world_df does not exist. Have you loaded the TopoJSON data to the correct variable name?"
     assert "topo_feature" in __solution__, "The loaded data should be in TopoJSON format. In order to read TopoJSON file correctly, you need to use the alt.topo_feature() function."
     assert type(world_df) == alt.UrlData, "world_df does not appear to be an Altair UrlData object. Have you assigned the Altair UrlData object for the TopoJSON data to the correct variable?"
-    assert world_df.url == data.world_110m.url, "Make sure you are loading the data from correct url."
+    assert world_df.url == data.world_110m.url, "Make sure you are loading the data from the correct url."
     assert (world_df.format !=  alt.utils.schemapi.Undefined and 
             world_df.format.type == 'topojson'
     ), "The loaded data should be in TopoJSON format. In order to read TopoJSON file correctly, you need to use the alt.topo_feature() function."

--- a/exercises/en/test_06_08b.py
+++ b/exercises/en/test_06_08b.py
@@ -1,0 +1,48 @@
+def test():
+    # Here we can either check objects created in the solution code, or the
+    # string value of the solution, available as __solution__. A helper for
+    # printing formatted messages is available as __msg__. See the testTemplate
+    # in the meta.json for details.
+    # If an assertion fails, the message will be displayed
+
+    assert not world_df is None, "Your answer for world_df does not exist. Have you loaded the TopoJSON data to the correct variable name?"
+    assert "topo_feature" in __solution__, "The loaded data should be in TopoJSON format. In order to read TopoJSON file correctly, you need to use the alt.topo_feature() function."
+    assert (
+        "quantitative" in __solution__ or 
+        "pop_density:Q" in __solution__
+    ), "Make sure you use pop_density column from gapminder_df for the color encoding. Hint: since pop_density column does not exist in world_df, Altair can't infer its data type and you need to specify that it is quantitative data."
+    assert type(world_df) == alt.UrlData, "world_df does not appear to be an Altair UrlData object. Have you assigned the Altair UrlData object for the TopoJSON data to the correct variable?"
+    assert world_df.url == data.world_110m.url, "Make sure you are loading the data from correct url."
+    assert (world_df.format != alt.utils.schemapi.Undefined and 
+            world_df.format.type == 'topojson'
+    ), "The loaded data should be in TopoJSON format. In order to read TopoJSON file correctly, you need to use the alt.topo_feature() function."
+    assert world_df.format.feature == "countries", "Make sure to specify 'countries' feature when loading the TopoJSON file using alt.topo_feature()."
+
+    assert not pop_dense_plot is None, "Your answer for pop_dense_plot does not exist. Have you assigned the plot to the correct variable name?"
+    assert type(pop_dense_plot) == alt.Chart, "pop_dense_plot does not appear to be an Altair Chart object. Have you assigned the Altair Chart object for the plot to the correct variable?"
+    assert pop_dense_plot.mark == 'geoshape', "Make sure you are using mark_geoshape for pop_dense_plot."
+
+    assert pop_dense_plot.encoding.color != alt.utils.schemapi.Undefined and (
+        pop_dense_plot.encoding.color.shorthand in {'pop_density:quantitative', 'pop_density:Q'} or
+        (pop_dense_plot.encoding.color.shorthand == 'pop_density' and pop_dense_plot.encoding.color.type == 'quantitative') or
+        pop_dense_plot.encoding.color.field in {'pop_density:quantitative', 'pop_density:Q'} or
+        (pop_dense_plot.encoding.color.field == 'pop_density' and pop_dense_plot.encoding.color.type == 'quantitative')
+    ), "Make sure you use pop_density column from gapminder_df for the color encoding. Hint: since pop_density column does not exist in world_df, Altair can't infer its data type and you need to specify that it is quantitative data."
+
+    assert pop_dense_plot.encoding.color.scale != alt.utils.schemapi.Undefined and (
+        pop_dense_plot.encoding.color.scale.scheme != alt.utils.schemapi.Undefined
+    ), "Make sure to specify a colour scheme."
+    assert pop_dense_plot.encoding.color.scale.domainMid == 81, "Make sure you set the domainMid of the color scale as the global median (81)."
+
+    assert type(pop_dense_plot.transform) == list and (
+        len(pop_dense_plot.transform) == 1 and
+        pop_dense_plot.transform[0]['from'] != alt.utils.schemapi.Undefined and
+        pop_dense_plot.transform[0]['from'].fields == ['pop_density'] and
+        pop_dense_plot.transform[0]['from'].key
+    ), "Make sure you use .transform_lookup() to lookup the column 'pop_density' from the gapminder_df data using 'id' as the connecting column. Hint: 'pop_density' should be inside a list."
+
+    assert pop_dense_plot.projection != alt.utils.schemapi.Undefined and (
+        pop_dense_plot.projection.scale == 80
+    ), "Make sure you use 'equalEarth' projection. Hint: you can use .project() method with type argument to specify projection type."    
+
+    __msg__.good("You're correct, well done!")

--- a/exercises/en/test_06_12.py
+++ b/exercises/en/test_06_12.py
@@ -1,0 +1,31 @@
+def test():
+    # Here we can either check objects created in the solution code, or the
+    # string value of the solution, available as __solution__. A helper for
+    # printing formatted messages is available as __msg__. See the testTemplate
+    # in the meta.json for details.
+    # If an assertion fails, the message will be displayed
+
+    assert not (
+        mass_density_plot is None or
+        mass_boxplot is None or
+        penguin_heatmap is None or 
+        culmen_facet_plot is None
+    ), "Make sure correct plots are still assigned to mass_density_plot, mass_boxplot, penguin_heatmap, and culmen_facet_plot in your solution"
+    assert not combined_plot is None, "Your answer for combined_plot does not exist. Have you assigned the plot to the correct variable name?"
+    
+    assert type(combined_plot) == alt.VConcatChart, "combined_plot does not appear to be an Altair VConcatChart object. Hint: note that mass_density_plot is at the top of the row. Try experimenting with & and | operators with appropriate parentheses to reproduce the same plot."
+    assert len(combined_plot.vconcat) == 3, "Make sure combined_plot has 3 rows."
+
+    # top row plot
+    plot1 = combined_plot.vconcat.pop(0); plot1.data = combined_plot.data
+    assert plot1 == mass_density_plot, "Top row of combined_plot should be mass_density_plot."
+
+    # second row plot
+    plot2 = combined_plot.vconcat.pop(0); plot2.data = combined_plot.data
+    assert plot2 == mass_boxplot | penguin_heatmap, "Second row of combined_plot should contain mass_boxplot and penguin_heatmap. Make sure they are also in the correct order."
+
+    # third row plot
+    plot3 = combined_plot.vconcat.pop(0); plot3.data = combined_plot.data
+    assert plot3 == culmen_facet_plot, "Last row of combined_plot should be culmen_facet_plot."
+    
+    __msg__.good("You're correct, well done!")


### PR DESCRIPTION
`Exc_06_08a `

Instruction should say 
> height and width dimensions of 400 and 580, respectively

instead of 
> height and width dimensions of 580 and 400, respectively

I think the hints may be incomplete. Also, should the first line of hints say data instead of lada?

`Exc_06_08b`

Instruction says 
> zooming in with a scale of 80 and panning to , respectively. 

Should it only ask for 
>zooming in with a scale of 80

since the starter code already has `translate=[290, 240]`?

`Exc_06_12`
I bounded the combined plot object to a variable named `combined_plot` in the `exc` and `solution` files to make it easier to test the plot object.

There may be some redundancy in the tests. Please let me know any changes that should be made. Thanks!