### PR TITLE
Make radio button options work with multiline text

### DIFF
--- a/src/quiz.js
+++ b/src/quiz.js
@@ -32,7 +32,11 @@ function generateQuiz(containerId, title, question, options, correctAnswer) {
 
     Object.entries(options).forEach(([option, explanation], index) => {
         const div = document.createElement('div');
-        div.className = 'form-check d-flex align-items-center'; // Flexbox for vertical alignment
+        div.className = 'form-check';
+        div.style.display = 'grid';
+        div.style.gridTemplateColumns = 'auto 1fr'; // Ensures radio button and text alignment
+        div.style.alignItems = 'start'; // Align radio button with first line
+        div.style.marginBottom = '5px';
 
         const input = document.createElement('input');
         input.type = 'radio';
@@ -40,7 +44,6 @@ function generateQuiz(containerId, title, question, options, correctAnswer) {
         input.value = option;
         input.className = 'form-check-input me-2'; // Added margin for spacing
         input.id = `option-${containerId}-${index}`;
-        input.style.marginTop = '0'; // Ensure no extra space pushes text down
         input.style.borderColor = '#4853A4'; // Radio button outline
         input.style.boxShadow = 'none';  // Remove brief occurances of transparent fill when clicked
         input.style.outline = 'none';  // Remove brief occurances of transparent fill when clicked


### PR DESCRIPTION
I'm unsure if these two lines are technically needed, but leaving them in for now:

        div.style.alignItems = 'start'; // Align radio button with first line
        div.style.marginBottom = '5px';